### PR TITLE
Link to official tutorial for port forwarding, that works for HDP2.6 as well

### DIFF
--- a/installation/HortonworksSandboxConfiguration.rst
+++ b/installation/HortonworksSandboxConfiguration.rst
@@ -73,7 +73,7 @@ This table shows the ports to add.
 | MySQL                   | 3306        | 3306         |                                                                                                      |
 +-------------------------+-------------+--------------+------------------------------------------------------------------------------------------------------+
 
-.. note:: The current HDP 2.5 sandbox for VirtualBox now uses Docker container, which means configuring port-forwarding in the VirtualBox UI is not enough anymore. You should do some extra steps described in: |port-forwarding-link|
+.. note:: HDP 2.5+ sandbox for VirtualBox now uses Docker container, which means configuring port-forwarding in the VirtualBox UI is not enough anymore. You should do some extra steps described in: |port-forwarding-link|
 
 Startup the Sandbox
 ===================
@@ -108,4 +108,4 @@ After setting the password the Ambari server will be started.
 
 .. |port-forwarding-link| raw:: html
 
-   <a href="https://community.hortonworks.com/articles/65914/how-to-add-ports-to-the-hdp-25-virtualbox-sandbox.html" target="_blank">How to add ports to the HDP 2.5 VirtualBox Sandbox</a>
+   <a href="https://hortonworks.com/hadoop-tutorial/sandbox-port-forwarding-guide/#section_2" target="_blank">2.5+ Sandbox port forwarding on VirtualBox</a>


### PR DESCRIPTION
Changed link to official tutorial that works for HDP2.5+ https://hortonworks.com/hadoop-tutorial/sandbox-port-forwarding-guide/#section_2.